### PR TITLE
fixed the TODO about showing the full IPv4 address instead of just the first octet

### DIFF
--- a/bin/sc
+++ b/bin/sc
@@ -1,13 +1,12 @@
-#!/bin/sh
+#!/bin/bash
 # Wrapper to start tmux sessions for connections to hosts
 
 # This is a security test I like to perform - we want to show what
 # ssh binary is being used to prevent any trickery
 WHICH_SSH=`which ssh`
 
-# Show only the start of the hostname. 
-# TODO: Make this work better with IP addresses (only shows first octet)
-HOST=`echo $1|cut -d. -f1`
+# Show only the IPv4 address or the start of  the hostname.
+HOST=`grep -o '^\([0-9]\+\.\)\{3\}[0-9]\+\|^[^.]\+' <<<"${1}"`
 
 # Start tmux window
 tmux new-window -n ${HOST} "echo 'Using: $WHICH_SSH' ; ~/bin/sc-ssh ${1}"


### PR DESCRIPTION
I was online browsing and I stumbled upon your blog post and wanted to see what your repo had in it, and when I read this file I knew how to fix your TODO.
